### PR TITLE
Allow application retry before application failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ Here is a short description of those parameters:
 - `APP_MORGAN_LOG_FORMAT` - log format used by `clamav-rest-api` to display information about requests. More infor can be found [here](https://github.com/expressjs/morgan#predefined-formats)
 - `APP_MAX_FILE_SIZE` - max size (in bytes) of **single** file which will be accepted by `clamav-rest-api`. You have to also take care of `MaxScanSize`, `MaxFileSize`, etc. in your `clamd.conf` file.
 - `APP_MAX_FILES_NUMBER` - maximum number of files uploaded to scan
-- `CLAMD_IP` - ClamAV IP adress
-- `CLAMD_PORT` - ClamAV listen port
-- `CLAMD_TIMEOUT`- ClamAV timeout connection in miliseconds
+- `CLAMD_IP` - ClamAV IP adress (default: 127.0.0.1)
+- `CLAMD_PORT` - ClamAV listen port (default: 3310)
+- `CLAMD_TIMEOUT`- ClamAV timeout connection in miliseconds (default: 60000)
+- `STARTUP_RETRY`- Amount of times the API will attempt to connect to Clam before terminating (default: 30)
 
 As stated before you can set all those parameters by setting environment variables:
 

--- a/src/app.js
+++ b/src/app.js
@@ -4,7 +4,25 @@ const { makeServer } = require('./server');
 
 (async () => {
   try {
-    await makeServer(config);
+    var startupRetry = config.avConfig.clamdscan.startupRetry;
+    var count = 0;
+    var success = false;
+    while (count != startupRetry) {
+      count = count + 1;
+      try {
+        await makeServer(config);
+        success = true;
+        break;// Server is online.
+      }
+      catch (error) {
+        console.log(`"(${count}-${startupRetry}): Clam AV Server not ready!!"`);
+        console.log(error);
+        await new Promise(r => setTimeout(r, 5000));
+      }
+    }
+    if (success == false) {
+      throw new Error("Application failed to start. Please check the message log.");
+    }
   } catch (e) {
     console.log(e.message);
   }

--- a/src/config.js
+++ b/src/config.js
@@ -5,6 +5,7 @@ const avConfig = {
     host: process.env.CLAMD_IP || '127.0.0.1',
     port: process.env.CLAMD_PORT || 3310,
     timeout: parseInt(process.env.CLAMD_TIMEOUT || 60000),
+    startupRetry: parseInt(process.env.STARTUP_RETRY || 30),
     socket: null,
     active: true,
   },
@@ -24,9 +25,8 @@ const fuConfig = {
       JSON.stringify({
         success: false,
         data: {
-          error: `File size limit exceeded. Max size of uploaded file is: ${
-            process.env.APP_MAX_FILE_SIZE / 1024
-          } KB`,
+          error: `File size limit exceeded. Max size of uploaded file is: ${process.env.APP_MAX_FILE_SIZE / 1024
+            } KB`,
         },
       })
     );

--- a/src/config.js
+++ b/src/config.js
@@ -25,8 +25,9 @@ const fuConfig = {
       JSON.stringify({
         success: false,
         data: {
-          error: `File size limit exceeded. Max size of uploaded file is: ${process.env.APP_MAX_FILE_SIZE / 1024
-            } KB`,
+          error: `File size limit exceeded. Max size of uploaded file is: ${
+            process.env.APP_MAX_FILE_SIZE / 1024
+          } KB`,
         },
       })
     );


### PR DESCRIPTION
**The problem:**
The API has a design flaw which causes issues when running with the Azure web app instance under docker compose.

1. The Azure Web application comes online
2. Azure/Docker attempts to bring both the Clam AV scanner and API container online
3. The API container attempts to reach out and communicate with the Clam AV Scanner and fails with an error where the port/service is not yet online.
4. Azure see's that the container has gone offline and kills the entire web app including both containers.
5. When the containers go offline, the docker compose restart rule kicks in and attempts to bring the containers back online.. Which causes the process to start from step 1 (infinite loop)

**The Solution:**
I have implemented a retry loop in that allows the application to attempt to restart up to X amount of times without notifying azure that there is a problem. In addition, I have created a new variable STARTUP_RETRY that allows us to specify the amount of times the API container will retry before failure.

**REPRODUCE**
This issue can be easily reproduced on a local development environment using the following docker compose.
You will note that the app crashes and restarts numerous times while clam is getting ready.

```
version: '3.3'
services:
  clamav-rest:
    image: benzino77/clamav-rest-api
    depends_on:
      - clamav-server
    links:
      - clamav-server
    environment:
      APP_PORT: 8080
      APP_FORM_KEY: file
      CLAMD_IP: clamav-server
    restart: always
  clamav-server:
    image: clamav/clamav
```


**BEFORE**
![image](https://user-images.githubusercontent.com/16983537/154157483-a6da6937-5382-48de-a1ca-579a5fc17286.png)

**AFTER**
![image](https://user-images.githubusercontent.com/16983537/154157832-d7286412-6a02-40ab-aa8f-b5e4e2f1bed2.png)

