### PR TITLE
Use wait-for-it tool to wait for ClamAV instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ WORKDIR /clamav-rest-api
 
 COPY src ./src/
 COPY package.json package-lock.json ./
+COPY entrypoint.sh ./
 
-RUN  apt-get update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils wait-for-it && \
     npm install --production && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    chown -R node:node ./
+    chown -R node:node ./ && \
+	chmod +x ./entrypoint.sh
 
 USER node:node
-CMD ["npm", "start"]
+
+ENTRYPOINT ["/clamav-rest-api/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+while [ 1 ] ; do
+	wait-for-it -t 5 "${CLAMD_IP:-127.0.0.1}:${CLAMD_PORT:-3310}"
+	if [ $? -eq 0 ] ; then
+		break
+	fi
+done
+
+npm start


### PR DESCRIPTION
Hello @benzino77,

I saw that you installed the wait-for-it tool but it's not used. When CRA is started and if ClamAV is not started then CRA will stop. This is not very convenient : CRA should actively wait for ClamAV until it's started.

This PR makes use of wait-for-it to wait until ClamAV is started.