### PR TITLE
Add app_max_file_size to kubernetes example.

### DIFF
--- a/examples/k8s/cra-configmap.yml
+++ b/examples/k8s/cra-configmap.yml
@@ -7,3 +7,4 @@ data:
   node-env: 'production'
   clamd-ip: 'clamavd-service'
   app-form-key: 'FILES'
+  app-max-file-size: '10485760'

--- a/examples/k8s/cra.yml
+++ b/examples/k8s/cra.yml
@@ -37,6 +37,11 @@ spec:
                 configMapKeyRef:
                   name: cra-configmap
                   key: app-form-key
+            - name: APP_MAX_FILE_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: cra-configmap
+                  key: app-max-file-size
           ports:
             - containerPort: 3000
               protocol: TCP


### PR DESCRIPTION
Without the app_max_file_size environment variable the daemon just returns null for the is_infected value, no matter, it seems, what is sent.
Perhaps the daemon should have a fallback?