### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.3-buster-slim
+FROM node:19.8.1-buster-slim
 
 LABEL maintainer="Piotr Antczak <antczak.piotr@gmail.com>"
 WORKDIR /clamav-rest-api


### PR DESCRIPTION
fix: cve in base image

The trivy operator reported 18 critical cves for the base image of clamav-rest-api.
```
CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
 18        67     33       84    4
```

I updated the base image in my fork and deployed the new image in kubernetes, resulting in a reduced list of cves.
```
CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
1          22     8        78    1

```

The container did start and lgtm.
However I'm not a nodejs programmer so I cannot judge if this might have side effects due to the language update.


