### PR TITLE
Replaced scanStream with passthrough for stability.

### DIFF
--- a/src/utils/scanFile.js
+++ b/src/utils/scanFile.js
@@ -1,10 +1,30 @@
 const { Readable } = require('stream');
 
 const scanFile = async (upload, av) => {
+  if (upload.size <= 0) {
+    return {
+      name: upload.name,
+      is_infected: false,
+      viruses: [],
+    }
+  }
+  let chunk = new Buffer.from(upload.data);
+
   const fileStream = new Readable();
-  fileStream.push(upload.data);
-  fileStream.push(null);
-  const result = await av.scanStream(fileStream);
+  fileStream._read = () => {
+    fileStream.push(chunk);
+    chunk = null;
+  }
+
+  const tcpStream = av.passthrough();
+  fileStream.pipe(tcpStream);
+
+  const result = await new Promise(resolve => tcpStream.on("scan-complete", resolve).on("error", (error) => {
+    throw new Error(error);
+  }).on("timeout", (error) => {
+    throw new Error(error);
+  }));
+
   return {
     name: upload.name,
     is_infected: result.isInfected,


### PR DESCRIPTION
As described in issue #49 and https://github.com/kylefarris/clamscan/issues/101 it is more reliable to use clamscan.passthrough() rather than scanStream. This PR implements this.
In addition it takes care if the input file is of zero size which otherwise results in a hang.